### PR TITLE
fix(funasr): sanitize system Python environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare:python:uv": "uv sync && uv run python download_models.py",
     "prepare:python:embedded": "node scripts/prepare-embedded-python.js",
     "prepare:python:info": "node scripts/prepare-embedded-python.js --info",
+    "test:unit": "node --test test/*.test.js",
     "test:python": "node scripts/test-embedded-python.js",
     "test:python:info": "node scripts/test-embedded-python.js --info",
     "prebuild:mac": "npm run prepare:python:embedded && npm run build:renderer",

--- a/src/helpers/funasrManager.js
+++ b/src/helpers/funasrManager.js
@@ -163,7 +163,11 @@ class FunASRManager {
       }
     } else {
       // 使用系统Python时，清除可能干扰的嵌入式Python环境变量
-      // 不设置PYTHONHOME和PYTHONPATH，让系统Python使用自己的环境
+      delete env.PYTHONHOME;
+      delete env.PYTHONPATH;
+      delete env.LD_LIBRARY_PATH;
+      delete env.DYLD_LIBRARY_PATH;
+
       if (!this._cachedPythonEnv || this._lastEmbeddedCheck !== isUsingEmbedded) {
         this.logger.info && this.logger.info('构建系统Python环境变量', {
           note: '使用系统Python默认环境',

--- a/test/funasrManager.test.js
+++ b/test/funasrManager.test.js
@@ -1,0 +1,52 @@
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const path = require("node:path");
+const test = require("node:test");
+
+const FunASRManager = require("../src/helpers/funasrManager");
+
+function restoreEnvironment(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+test("system Python environment drops inherited embedded paths", () => {
+  const originalPythonHome = process.env.PYTHONHOME;
+  const originalPythonPath = process.env.PYTHONPATH;
+  const originalLdLibraryPath = process.env.LD_LIBRARY_PATH;
+  const originalDyldLibraryPath = process.env.DYLD_LIBRARY_PATH;
+  const originalLoad = Module._load;
+
+  process.env.PYTHONHOME = "/missing/ququ/python";
+  process.env.PYTHONPATH = "/missing/ququ/python/lib/python3.11/site-packages";
+  process.env.LD_LIBRARY_PATH = "/missing/ququ/python/lib";
+  process.env.DYLD_LIBRARY_PATH = "/missing/ququ/python/lib";
+  Module._load = function (request) {
+    if (request === "electron") {
+      return { app: { getPath: () => "/tmp/ququ-test" } };
+    }
+    return originalLoad.apply(this, arguments);
+  };
+
+  try {
+    const manager = new FunASRManager();
+    manager.getEmbeddedPythonPath = () =>
+      path.join("/missing", "ququ", "python", "bin", "python3.11");
+
+    const env = manager.buildPythonEnvironment();
+
+    assert.equal(Object.hasOwn(env, "PYTHONHOME"), false);
+    assert.equal(Object.hasOwn(env, "PYTHONPATH"), false);
+    assert.equal(Object.hasOwn(env, "LD_LIBRARY_PATH"), false);
+    assert.equal(Object.hasOwn(env, "DYLD_LIBRARY_PATH"), false);
+  } finally {
+    Module._load = originalLoad;
+    restoreEnvironment("PYTHONHOME", originalPythonHome);
+    restoreEnvironment("PYTHONPATH", originalPythonPath);
+    restoreEnvironment("LD_LIBRARY_PATH", originalLdLibraryPath);
+    restoreEnvironment("DYLD_LIBRARY_PATH", originalDyldLibraryPath);
+  }
+});


### PR DESCRIPTION
## Summary

- remove inherited embedded-Python path variables when QuQu uses a system Python
- add a focused `node:test` regression test and `npm run test:unit` entry point

## Context

In the system-Python branch, `buildPythonEnvironment()` starts by copying `process.env`. It previously avoided assigning embedded values, but did not remove existing `PYTHONHOME`, `PYTHONPATH`, `LD_LIBRARY_PATH`, or `DYLD_LIBRARY_PATH` entries inherited from the launcher or an earlier runtime setup.

Those stale paths can make the selected system Python fail before the model-download script starts, commonly with `ModuleNotFoundError: No module named 'encodings'`.

The original environment handling reported in #61 is already improved on `main` compared with the `v1.0.1` tag. This PR adds the remaining defensive cleanup plus a regression test so the failure does not return through inherited process state.

## Verification

- `npm run test:unit` (1 passed)
- `git diff --check`

Related to #61.
